### PR TITLE
ghast tear recipe fix

### DIFF
--- a/src/main/resources/data/vanrec/recipes/ghast_tear.json
+++ b/src/main/resources/data/vanrec/recipes/ghast_tear.json
@@ -5,13 +5,13 @@
     "B": {
       "item": "minecraft:blaze_rod"
     },
-    "W": {
-      "item": "minecraft:water_bucket"
+    "C": {
+      "item": "minecraft:crying_obsidian"
     }
   },
   "pattern": [
     " B ",
-    "BWB",
+    "BCB",
     " B "
   ],
   "result": {


### PR DESCRIPTION
**Changes**
- Change in the ghast tear recipe to use crying obsidian instead of a water bucket